### PR TITLE
Add optional error callback for failed initialization (#6)

### DIFF
--- a/src/MobileAnalyticsSessionManager.js
+++ b/src/MobileAnalyticsSessionManager.js
@@ -24,7 +24,7 @@ export default class Manager {
         this.options = options;
     }
     
-    async initialize(successFn, errorFn) {
+    async initialize(onSuccess, onConnectionFailure) {
 
         let isConnected = await NetInfo.isConnected.fetch();
 
@@ -32,19 +32,19 @@ export default class Manager {
             let options = this.options;
             if (options instanceof Client) {
                 this.client = options;
-                this.initSession(successFn);
+                this.initSession(onSuccess);
             } else {
                 options._autoSubmitEvents = options.autoSubmitEvents;
                 options.autoSubmitEvents = false;
                 this.client = new Client(options, ()=>{
                     options.autoSubmitEvents = options._autoSubmitEvents !== false;
                     delete options._autoSubmitEvents;
-                    this.initSession(successFn);
+                    this.initSession(onSuccess);
                 });
             }
         } else {
             console.log('[Function:(AMA.Manager).initialize: Not initializeable (no internet connection)]');
-            errorFn ? errorFn() : successFn();
+            onConnectionFailure ? onConnectionFailure() : onSuccess();
         }
 
     }

--- a/src/MobileAnalyticsSessionManager.js
+++ b/src/MobileAnalyticsSessionManager.js
@@ -23,8 +23,8 @@ export default class Manager {
     constructor(options) {
         this.options = options;
     }
-
-    async initialize(callback) {
+    
+    async initialize(successFn, errorFn) {
 
         let isConnected = await NetInfo.isConnected.fetch();
 
@@ -32,19 +32,19 @@ export default class Manager {
             let options = this.options;
             if (options instanceof Client) {
                 this.client = options;
-                this.initSession(callback);
+                this.initSession(successFn);
             } else {
                 options._autoSubmitEvents = options.autoSubmitEvents;
                 options.autoSubmitEvents = false;
                 this.client = new Client(options, ()=>{
                     options.autoSubmitEvents = options._autoSubmitEvents !== false;
                     delete options._autoSubmitEvents;
-                    this.initSession(callback);
+                    this.initSession(successFn);
                 });
             }
         } else {
             console.log('[Function:(AMA.Manager).initialize: Not initializeable (no internet connection)]');
-            callback();
+            errorFn ? errorFn() : successFn();
         }
 
     }


### PR DESCRIPTION
This adds an optional failure callback to the Manager.initialize method to allow for handling and recovering from failed initialization due to no network connection.

To make it backwards compatible, it'll fallback to the success callback if no failure callback was provided.

closes #6 